### PR TITLE
feat(cli): create generate-report command to create a CSV file with option to upload to S3

### DIFF
--- a/metadata-ingestion/src/datahub/cli/generate_report/config.py
+++ b/metadata-ingestion/src/datahub/cli/generate_report/config.py
@@ -5,22 +5,33 @@ from datahub.configuration.common import ConfigModel
 
 
 class OutputFormatEnum(str, Enum):
-    CSV = 'csv'
+    CSV = "csv"
+
 
 class FileOutput(ConfigModel):
     filepath: str
 
+
 class S3Output(ConfigModel):
     s3_bucket: str
+    # The key can include strftime format codes and it will be formated
+    # https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
     s3_key: str
+
 
 OutputDestination = Union[FileOutput, S3Output]
 
+
 class Output(ConfigModel):
     format: OutputFormatEnum
-    destination: OutputDestination
+    # Outputs can be exported to multiple destinations
+    destinations: List[OutputDestination]
+
 
 class GenerateReportConfig(ConfigModel):
     datahub_base_url: str
+    # Search query strings for https://datahubproject.io/docs/graphql/queries#search
     search_queries: List[str]
+    # Page size to use for the graphql query when fetching search results
+    search_query_page_size: int = 500
     output: Output

--- a/metadata-ingestion/src/datahub/cli/generate_report/config.py
+++ b/metadata-ingestion/src/datahub/cli/generate_report/config.py
@@ -1,0 +1,26 @@
+from enum import Enum
+from typing import List, Union
+
+from datahub.configuration.common import ConfigModel
+
+
+class OutputFormatEnum(str, Enum):
+    CSV = 'csv'
+
+class FileOutput(ConfigModel):
+    filepath: str
+
+class S3Output(ConfigModel):
+    s3_bucket: str
+    s3_key: str
+
+OutputDestination = Union[FileOutput, S3Output]
+
+class Output(ConfigModel):
+    format: OutputFormatEnum
+    destination: OutputDestination
+
+class GenerateReportConfig(ConfigModel):
+    datahub_base_url: str
+    search_queries: List[str]
+    output: Output

--- a/metadata-ingestion/src/datahub/cli/generate_report/report_generator.py
+++ b/metadata-ingestion/src/datahub/cli/generate_report/report_generator.py
@@ -115,9 +115,9 @@ class PrivacyTermExtractor:
     def _yield_graphql_search_results(
         self, search_query: str
     ) -> Generator[Dict, None, None]:
-        total = None
+        total_num_of_datasets = None
         offset = 0
-        while total is None or offset < total:
+        while total_num_of_datasets is None or offset < total_num_of_datasets:
             graphql_variables = {
                 "search_query": search_query,
                 "page_size": self.search_query_page_size,
@@ -135,7 +135,7 @@ class PrivacyTermExtractor:
                 yield entity
                 num_entities_processed_for_current_query += 1
 
-            total = response_json["data"]["search"]["total"]
+            total_num_of_datasets = response_json["data"]["search"]["total"]
             offset += num_entities_processed_for_current_query
 
     @classmethod

--- a/metadata-ingestion/src/datahub/cli/generate_report/report_generator.py
+++ b/metadata-ingestion/src/datahub/cli/generate_report/report_generator.py
@@ -4,7 +4,7 @@ import itertools
 import logging
 import os
 import tempfile
-from typing import Any, Dict, Generator, Iterable, TextIO
+from typing import Any, BinaryIO, Dict, Generator, Iterable, TextIO
 
 import boto3
 import requests
@@ -29,10 +29,13 @@ class ReportGenerator:
     def generate(self) -> int:
         extractor = PrivacyTermExtractor(self.config.datahub_base_url)
         rows = extractor.yield_search_results(self.config.search_queries)
-        with OutputExporter(self.config.output.destination) as exporter:
-            output_writer = OutputWriter(self.config.output.format, exporter.fileobj)
+        with tempfile.NamedTemporaryFile("w") as tmp_file:
+            output_writer = OutputWriter(self.config.output.format, tmp_file)
             output_writer.write(rows)
-            exporter.export()
+            with open(tmp_file.name, "rb") as tmp_file_binary:
+                for destination in self.config.output.destinations:
+                    tmp_file_binary.seek(0)
+                    OutputExporter.export(destination, tmp_file_binary)
         return 0
 
     @classmethod
@@ -40,10 +43,9 @@ class ReportGenerator:
         config = GenerateReportConfig.parse_obj(config_dict)
         return cls(config)
 
+
 class PrivacyTermExtractor:
-    DATAHUB_GRAPHQL_ENDPOINT: str = '/api/graphql'
-    PAGE_SIZE: int = 500
-    MAX_SEARCH_RESULTS_TOTAL: int = 100000
+    DATAHUB_GRAPHQL_ENDPOINT: str = "/api/graphql"
     GRAPHQL_QUERY: str = """
     query GetDatasetGlossaryTerms($search_query: String!, $page_size: Int, $offset:Int) {
       search(input: {
@@ -93,79 +95,91 @@ class PrivacyTermExtractor:
     }
     """
     graphql_api_url: str
+    search_query_page_size: int = 500
 
-    def __init__(self, datahub_base_url: str) -> None:
-        self.graphql_api_url = f'{datahub_base_url}{self.DATAHUB_GRAPHQL_ENDPOINT}'
+    def __init__(
+        self, datahub_base_url: str, search_query_page_size: int = 500
+    ) -> None:
+        self.graphql_api_url = f"{datahub_base_url}{self.DATAHUB_GRAPHQL_ENDPOINT}"
+        self.search_query_page_size = search_query_page_size
 
-    def yield_search_results(self, search_queries: Iterable[str]) -> Generator[Dict, None, None]:
+    def yield_search_results(
+        self, search_queries: Iterable[str]
+    ) -> Generator[Dict, None, None]:
         return itertools.chain.from_iterable(
             self._yield_rows(entity)
             for search_query in search_queries
             for entity in self._yield_graphql_search_results(search_query)
         )
 
-    def _yield_graphql_search_results(self, search_query: str) -> Generator[Dict, None, None]:
-        total = self.MAX_SEARCH_RESULTS_TOTAL
+    def _yield_graphql_search_results(
+        self, search_query: str
+    ) -> Generator[Dict, None, None]:
+        total = None
         offset = 0
-        while offset < total:
+        while total is None or offset < total:
             graphql_variables = {
-                'search_query': search_query,
-                'page_size': self.PAGE_SIZE,
-                'offset': offset
+                "search_query": search_query,
+                "page_size": self.search_query_page_size,
+                "offset": offset,
             }
-            logger.info(f'Issuing graphql query with variables: {graphql_variables}')
+            logger.info(f"Issuing graphql query with variables: {graphql_variables}")
 
-            payload = {'query': self.GRAPHQL_QUERY, 'variables': graphql_variables}
+            payload = {"query": self.GRAPHQL_QUERY, "variables": graphql_variables}
             response = requests.post(self.graphql_api_url, json=payload)
             response.raise_for_status()
             response_json = response.json()
-            for entity in response_json['data']['search']['searchResults']:
-                yield entity
 
-            total = response_json['data']['search']['total']
-            if total > self.MAX_SEARCH_RESULTS_TOTAL:
-                msg = f'graphql query total results ({total}) exceeds maximum ({self.MAX_SEARCH_RESULTS_TOTAL})'
-                raise RuntimeError(msg)
-            offset += self.PAGE_SIZE
+            num_entities_processed_for_current_query = 0
+            for entity in response_json["data"]["search"]["searchResults"]:
+                yield entity
+                num_entities_processed_for_current_query += 1
+
+            total = response_json["data"]["search"]["total"]
+            offset += num_entities_processed_for_current_query
 
     @classmethod
     def _yield_rows(cls, entity: Dict) -> Generator[Dict, None, None]:
         # Merge glossaryTerms from both schemaMetadata and editableSchemaMetadata
         merged_rows = {}
         # schemaMetadata will contain all fields
-        for field in entity['entity']['schemaMetadata']['fields']:
-            merged_rows[field['fieldPath']] = {
-                'dataset': entity['entity']['schemaMetadata']['name'],
-                'field': field['fieldPath'],
-                'type': [],
-                'privacy_law': [],
+        for field in entity["entity"]["schemaMetadata"]["fields"]:
+            merged_rows[field["fieldPath"]] = {
+                "dataset": entity["entity"]["schemaMetadata"]["name"],
+                "field": field["fieldPath"],
+                "type": [],
+                "privacy_law": [],
             }
-            cls._add_terms_to_row(merged_rows[field['fieldPath']], field)
+            cls._add_terms_to_row(merged_rows[field["fieldPath"]], field)
 
         # editableSchemaMetadata can be empty or contain subset of fields
-        if entity['entity']['editableSchemaMetadata']:
-            for field in entity['entity']['editableSchemaMetadata']['editableSchemaFieldInfo']:
-                cls._add_terms_to_row(merged_rows[field['fieldPath']], field)
+        if entity["entity"]["editableSchemaMetadata"]:
+            for field in entity["entity"]["editableSchemaMetadata"][
+                "editableSchemaFieldInfo"
+            ]:
+                cls._add_terms_to_row(merged_rows[field["fieldPath"]], field)
 
         yield from merged_rows.values()
 
     @classmethod
     def _add_terms_to_row(cls, row: Dict, field: Dict) -> None:
-        if not field['glossaryTerms']:
+        if not field["glossaryTerms"]:
             return
-        for term in field['glossaryTerms']['terms']:
-            term_id = term['term']['urn'].split(':')[-1]
-            if term_id.startswith('PiiData'):
-                row['type'].append(term_id.split('.')[-1])
-            if term_id.startswith('PrivacyLaw'):
-                row['privacy_law'].append(term_id.split('.')[-1])
+        for term in field["glossaryTerms"]["terms"]:
+            term_id = term["term"]["urn"].split(":")[-1]
+            if term_id.startswith("PiiData"):
+                row["type"].append(term_id.split(".")[-1])
+            if term_id.startswith("PrivacyLaw"):
+                row["privacy_law"].append(term_id.split(".")[-1])
+
 
 class OutputWriter:
-    """ Handles writing to a `fileobj` based on the `output_format`.
+    """Handles writing to a `fileobj` based on the `output_format`.
 
     - `write` will write to the `fileobj` passed in in constructor
     - `fileobj` should be managed outside of this class
     """
+
     output_format: OutputFormatEnum
     fileobj: TextIO
 
@@ -177,71 +191,44 @@ class OutputWriter:
         if self.output_format == OutputFormatEnum.CSV:
             self._write_csv(rows)
         else:
-            raise ValueError(f'unhandled output format: {self.output_format}')
+            raise ValueError(f"unhandled output format: {self.output_format}")
 
     def _write_csv(self, rows: Iterable[Dict]) -> None:
-        fieldnames = ['dataset', 'field', 'type', 'privacy_law']
+        fieldnames = ["dataset", "field", "type", "privacy_law"]
         writer = csv.DictWriter(self.fileobj, fieldnames=fieldnames)
         writer.writeheader()
         for row in rows:
             # TODO: make this more generic rather than just privacy
             # transform lists to be csv friendly
-            row['type'] = ', '.join(sorted(row['type']))
-            row['privacy_law'] = ', '.join(sorted(row['privacy_law']))
+            row["type"] = ", ".join(sorted(row["type"]))
+            row["privacy_law"] = ", ".join(sorted(row["privacy_law"]))
             writer.writerow(row)
 
+
 class OutputExporter:
-    """Use this as a context manager. Write using `fileobj` property and call `export()`.
-    The `fileobj` will be closed on context manager exit.
-
-    >>> with OutputExporter(destination) as exporter:
-    >>>     exporter.fileobj.write(...)
-    >>>     exporter.export()
-    """
-
-    output_destination: OutputDestination
-    _fileobj: TextIO
-
-    def __init__(self, output_destination: OutputDestination):
-        self.output_destination = output_destination
-        destination_type = type(self.output_destination)
+    @staticmethod
+    def export(output_destination: OutputDestination, fileobj: BinaryIO):
+        destination_type = type(output_destination)
         if destination_type == FileOutput:
-            self._fileobj = open(output_destination.filepath, 'w')
+            logger.info(
+                f"Writing output to: {os.path.abspath(output_destination.filepath)}"
+            )
+            with open(output_destination.filepath, "wb") as f:
+                f.write(fileobj.read())
         elif destination_type == S3Output:
-            self._fileobj = tempfile.NamedTemporaryFile('w')
+            bucket = output_destination.s3_bucket
+            key = datetime.datetime.utcnow().strftime(output_destination.s3_key)
+            S3FileUploader().upload_fileobj(fileobj, bucket, key)
         else:
-            raise ValueError(f'unhandled output destination type: {destination_type}')
+            raise ValueError(f"unhandled output destination type: {destination_type}")
 
-    def __enter__(self) -> None:
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
-        self._fileobj.close()
-
-    @property
-    def fileobj(self) -> TextIO:
-        return self._fileobj
-
-    def export(self):
-        if type(self.output_destination) == FileOutput:
-            # File should be written to, nothing to export
-            logger.info(f'Output at: {os.path.abspath(self._fileobj.name)}')
-        elif type(self.output_destination) == S3Output:
-            # set file to beginning before upload
-            # or else it will upload an empty file.
-            self.fileobj.seek(0)
-            bucket = self.output_destination.s3_bucket
-            key = datetime.datetime.utcnow().strftime(self.output_destination.s3_key)
-            S3FileUploader().upload(self.fileobj.name, bucket, key)
-        else:
-            raise ValueError(f'unhandled output destination: {self.output_destination}')
 
 class S3FileUploader:
     s3_client: Any
 
     def __init__(self, s3_client=None) -> None:
-        self.s3_client = s3_client or boto3.Session().client('s3')
+        self.s3_client = s3_client or boto3.Session().client("s3")
 
-    def upload(self, src_filepath, s3_bucket, s3_key) -> None:
-        logger.info(f'Uploading {src_filepath} to s3://{s3_bucket}/{s3_key}')
-        self.s3_client.upload_file(src_filepath, s3_bucket, s3_key)
+    def upload_fileobj(self, fileobj: BinaryIO, s3_bucket, s3_key) -> None:
+        logger.info(f"Uploading to s3://{s3_bucket}/{s3_key}")
+        self.s3_client.upload_fileobj(fileobj, s3_bucket, s3_key)

--- a/metadata-ingestion/src/datahub/cli/generate_report/report_generator.py
+++ b/metadata-ingestion/src/datahub/cli/generate_report/report_generator.py
@@ -1,0 +1,237 @@
+import csv
+import datetime
+import itertools
+import logging
+import tempfile
+from typing import Any, Dict, Generator, Iterable, TextIO
+
+import boto3
+import requests
+
+from datahub.cli.generate_report.config import (
+    FileOutput,
+    GenerateReportConfig,
+    OutputDestination,
+    OutputFormatEnum,
+    S3Output,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class ReportGenerator:
+    config: GenerateReportConfig
+
+    def __init__(self, config: GenerateReportConfig) -> None:
+        self.config = config
+
+    def generate(self) -> int:
+        extractor = PrivacyTermExtractor(self.config.datahub_base_url)
+        rows = extractor.yield_search_results(self.config.search_queries)
+        with OutputExporter(self.config.output.destination) as exporter:
+            output_writer = OutputWriter(self.config.output.format, exporter.fileobj)
+            output_writer.write(rows)
+            exporter.export()
+        return 0
+
+    @classmethod
+    def create(cls, config_dict: dict) -> "ReportGenerator":
+        config = GenerateReportConfig.parse_obj(config_dict)
+        return cls(config)
+
+class PrivacyTermExtractor:
+    DATAHUB_GRAPHQL_ENDPOINT: str = '/api/graphql'
+    PAGE_SIZE: int = 500
+    MAX_SEARCH_RESULTS_TOTAL: int = 100000
+    GRAPHQL_QUERY: str = """
+    query GetDatasetGlossaryTerms($search_query: String!, $page_size: Int, $offset:Int) {
+      search(input: {
+        type: DATASET,
+        # search query cannot be empty, use "*" or by searching for a specific dataPlatoform name e.g. snowflake
+        query: $search_query,
+        count: $page_size,
+        start: $offset,
+      }) {
+        total
+        searchResults {
+          entity {
+            ... on Dataset {
+              urn
+              editableSchemaMetadata {
+                editableSchemaFieldInfo {
+                  fieldPath
+                  glossaryTerms {
+                    terms {
+                      term {
+                        urn
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+              # zero represents the latest version with otherwise monotonic ordering starting at one.
+              schemaMetadata(version: 0) {
+                name
+                fields {
+                  fieldPath
+                  glossaryTerms {
+                    terms {
+                      term {
+                        urn
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    graphql_api_url: str
+
+    def __init__(self, datahub_base_url: str) -> None:
+        self.graphql_api_url = f'{datahub_base_url}{self.DATAHUB_GRAPHQL_ENDPOINT}'
+
+    def yield_search_results(self, search_queries: Iterable[str]) -> Generator[Dict, None, None]:
+        return itertools.chain.from_iterable(
+            self.yield_rows(entity)
+            for search_query in search_queries
+            for entity in self.yield_search_results_single_query(search_query)
+        )
+
+    def yield_search_results_single_query(self, search_query: str) -> Generator[Dict, None, None]:
+        total = self.MAX_SEARCH_RESULTS_TOTAL
+        offset = 0
+        while offset < total:
+            graphql_variables = {
+                'search_query': search_query,
+                'page_size': self.PAGE_SIZE,
+                'offset': offset
+            }
+
+            payload = {'query': self.GRAPHQL_QUERY, 'variables': graphql_variables}
+            response = requests.post(self.graphql_api_url, json=payload)
+            response.raise_for_status()
+            response_json = response.json()
+            for entity in response_json['data']['search']['searchResults']:
+                yield entity
+
+            total = response_json['data']['search']['total']
+            if total > self.MAX_SEARCH_RESULTS_TOTAL:
+                msg = f'graphql query total results ({total}) exceeds maximum ({self.MAX_SEARCH_RESULTS_TOTAL})'
+                raise RuntimeError(msg)
+            offset += self.PAGE_SIZE
+
+    @classmethod
+    def yield_rows(cls, entity: Dict) -> Generator[Dict, None, None]:
+        # Merge glossaryTerms from both schemaMetadata and editableSchemaMetadata
+        merged_rows = {}
+        # schemaMetadata will contain all fields
+        for field in entity['entity']['schemaMetadata']['fields']:
+            merged_rows[field['fieldPath']] = {
+                'dataset': entity['entity']['schemaMetadata']['name'],
+                'field': field['fieldPath'],
+                'type': [],
+                'privacy_law': [],
+            }
+            cls.add_terms_to_row(merged_rows[field['fieldPath']], field)
+
+        # editableSchemaMetadata can be empty or contain subset of fields
+        if entity['entity']['editableSchemaMetadata']:
+            for field in entity['entity']['editableSchemaMetadata']['editableSchemaFieldInfo']:
+                cls.add_terms_to_row(merged_rows[field['fieldPath']], field)
+
+        yield from merged_rows.values()
+
+    @classmethod
+    def add_terms_to_row(cls, row: Dict, field: Dict) -> None:
+        if not field['glossaryTerms']:
+            return
+        for term in field['glossaryTerms']['terms']:
+            term_id = term['term']['urn'].split(':')[-1]
+            if term_id.startswith('PiiData'):
+                row['type'].append(term_id.split('.')[-1])
+            if term_id.startswith('PrivacyLaw'):
+                row['privacy_law'].append(term_id.split('.')[-1])
+
+class OutputWriter:
+    def __init__(self, output_format: OutputFormatEnum, fileobj: TextIO):
+        self.output_format = output_format
+        self.fileobj = fileobj
+
+    def write(self, rows: Iterable[Dict]):
+        if self.output_format == OutputFormatEnum.CSV:
+            self._write_csv(rows)
+        else:
+            raise ValueError(f'unhandled output format: {self.output_format}')
+
+    def _write_csv(self, rows: Iterable[Dict]) -> None:
+        fieldnames = ['dataset', 'field', 'type', 'privacy_law']
+        writer = csv.DictWriter(self.fileobj, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            # TODO: make this more generic rather than just privacy
+            # transform lists to be csv friendly
+            row['type'] = ', '.join(sorted(row['type']))
+            row['privacy_law'] = ', '.join(sorted(row['privacy_law']))
+            writer.writerow(row)
+
+class OutputExporter:
+    """Use this as a context manager. Write using `fileobj` property and call `export()`.
+    The `fileobj` will be closed on context manager exit.
+
+    >>> with OutputExporter(destination) as exporter:
+    >>>     exporter.fileobj.write(...)
+    >>>     exporter.export()
+    """
+
+    output_destination: OutputDestination
+    _fileobj: TextIO
+
+    def __init__(self, output_destination: OutputDestination):
+        self.output_destination = output_destination
+        destination_type = type(self.output_destination)
+        if destination_type == FileOutput:
+            self._fileobj = open(output_destination.filepath, 'w')
+        elif destination_type == S3Output:
+            self._fileobj = tempfile.NamedTemporaryFile('w')
+        else:
+            raise ValueError(f'unhandled output destination type: {destination_type}')
+
+    def __enter__(self) -> None:
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self._fileobj.close()
+
+    @property
+    def fileobj(self) -> TextIO:
+        return self._fileobj
+
+    def export(self):
+        if type(self.output_destination) == FileOutput:
+            # File should be written to, nothing to export
+            pass
+        elif type(self.output_destination) == S3Output:
+            # set file to beginning before upload
+            # or else it will upload an empty file.
+            self.fileobj.seek(0)
+            bucket = self.output_destination.s3_bucket
+            key = datetime.datetime.utcnow().strftime(self.output_destination.s3_key)
+            S3FileUploader().upload(self.fileobj.name, bucket, key)
+        else:
+            raise ValueError(f'unhandled output destination: {self.output_destination}')
+
+class S3FileUploader:
+    s3_client: Any
+
+    def __init__(self, s3_client=None) -> None:
+        self.s3_client = s3_client or boto3.Session().client('s3')
+
+    def upload(self, src_filepath, s3_bucket, s3_key) -> None:
+        logger.info(f'Uploading {src_filepath} to s3://{s3_bucket}/{s3_key}')
+        self.s3_client.upload_file(src_filepath, s3_bucket, s3_key)

--- a/metadata-ingestion/src/datahub/cli/generate_report/report_generator.py
+++ b/metadata-ingestion/src/datahub/cli/generate_report/report_generator.py
@@ -2,6 +2,7 @@ import csv
 import datetime
 import itertools
 import logging
+import os
 import tempfile
 from typing import Any, Dict, Generator, Iterable, TextIO
 
@@ -112,7 +113,7 @@ class PrivacyTermExtractor:
                 'page_size': self.PAGE_SIZE,
                 'offset': offset
             }
-            logger.info(f'Issuing graphql queries with variables: {graphql_variables}')
+            logger.info(f'Issuing graphql query with variables: {graphql_variables}')
 
             payload = {'query': self.GRAPHQL_QUERY, 'variables': graphql_variables}
             response = requests.post(self.graphql_api_url, json=payload)
@@ -224,7 +225,7 @@ class OutputExporter:
     def export(self):
         if type(self.output_destination) == FileOutput:
             # File should be written to, nothing to export
-            pass
+            logger.info(f'Output at: {os.path.abspath(self._fileobj.name)}')
         elif type(self.output_destination) == S3Output:
             # set file to beginning before upload
             # or else it will upload an empty file.

--- a/metadata-ingestion/src/datahub/cli/generate_report/report_generator.py
+++ b/metadata-ingestion/src/datahub/cli/generate_report/report_generator.py
@@ -70,7 +70,7 @@ class PrivacyTermExtractor:
                   }
                 }
               }
-              # zero represents the latest version with otherwise monotonic ordering starting at one.
+              # zero represents the latest version
               schemaMetadata(version: 0) {
                 name
                 fields {
@@ -112,6 +112,7 @@ class PrivacyTermExtractor:
                 'page_size': self.PAGE_SIZE,
                 'offset': offset
             }
+            logger.info(f'Issuing graphql queries with variables: {graphql_variables}')
 
             payload = {'query': self.GRAPHQL_QUERY, 'variables': graphql_variables}
             response = requests.post(self.graphql_api_url, json=payload)
@@ -159,6 +160,14 @@ class PrivacyTermExtractor:
                 row['privacy_law'].append(term_id.split('.')[-1])
 
 class OutputWriter:
+    """ Handles writing to a `fileobj` based on the `output_format`.
+
+    - `write` will write to the `fileobj` passed in in constructor
+    - `fileobj` should be managed outside of this class
+    """
+    output_format: OutputFormatEnum
+    fileobj: TextIO
+
     def __init__(self, output_format: OutputFormatEnum, fileobj: TextIO):
         self.output_format = output_format
         self.fileobj = fileobj

--- a/metadata-ingestion/src/datahub/cli/generate_report/report_generator.py
+++ b/metadata-ingestion/src/datahub/cli/generate_report/report_generator.py
@@ -99,12 +99,12 @@ class PrivacyTermExtractor:
 
     def yield_search_results(self, search_queries: Iterable[str]) -> Generator[Dict, None, None]:
         return itertools.chain.from_iterable(
-            self.yield_rows(entity)
+            self._yield_rows(entity)
             for search_query in search_queries
-            for entity in self.yield_search_results_single_query(search_query)
+            for entity in self._yield_graphql_search_results(search_query)
         )
 
-    def yield_search_results_single_query(self, search_query: str) -> Generator[Dict, None, None]:
+    def _yield_graphql_search_results(self, search_query: str) -> Generator[Dict, None, None]:
         total = self.MAX_SEARCH_RESULTS_TOTAL
         offset = 0
         while offset < total:
@@ -129,7 +129,7 @@ class PrivacyTermExtractor:
             offset += self.PAGE_SIZE
 
     @classmethod
-    def yield_rows(cls, entity: Dict) -> Generator[Dict, None, None]:
+    def _yield_rows(cls, entity: Dict) -> Generator[Dict, None, None]:
         # Merge glossaryTerms from both schemaMetadata and editableSchemaMetadata
         merged_rows = {}
         # schemaMetadata will contain all fields
@@ -140,17 +140,17 @@ class PrivacyTermExtractor:
                 'type': [],
                 'privacy_law': [],
             }
-            cls.add_terms_to_row(merged_rows[field['fieldPath']], field)
+            cls._add_terms_to_row(merged_rows[field['fieldPath']], field)
 
         # editableSchemaMetadata can be empty or contain subset of fields
         if entity['entity']['editableSchemaMetadata']:
             for field in entity['entity']['editableSchemaMetadata']['editableSchemaFieldInfo']:
-                cls.add_terms_to_row(merged_rows[field['fieldPath']], field)
+                cls._add_terms_to_row(merged_rows[field['fieldPath']], field)
 
         yield from merged_rows.values()
 
     @classmethod
-    def add_terms_to_row(cls, row: Dict, field: Dict) -> None:
+    def _add_terms_to_row(cls, row: Dict, field: Dict) -> None:
         if not field['glossaryTerms']:
             return
         for term in field['glossaryTerms']['terms']:

--- a/metadata-ingestion/src/datahub/cli/generate_report_cli.py
+++ b/metadata-ingestion/src/datahub/cli/generate_report_cli.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import pathlib
 import sys
 
@@ -7,10 +6,11 @@ import click
 from pydantic import ValidationError
 
 import datahub as datahub_package
-from datahub.configuration.config_loader import load_config_file
 from datahub.cli.generate_report.report_generator import ReportGenerator
+from datahub.configuration.config_loader import load_config_file
 
 logger = logging.getLogger(__name__)
+
 
 @click.command()
 @click.option(

--- a/metadata-ingestion/src/datahub/cli/generate_report_cli.py
+++ b/metadata-ingestion/src/datahub/cli/generate_report_cli.py
@@ -1,46 +1,40 @@
-# TODO impl https://jira.team.affirm.com/browse/DF-1739
-
 import logging
 import os
 import pathlib
 import sys
 
 import click
-from click_default_group import DefaultGroup
 from pydantic import ValidationError
-from tabulate import tabulate
 
 import datahub as datahub_package
 from datahub.configuration.config_loader import load_config_file
-from datahub.ingestion.run.pipeline import Pipeline
+from datahub.cli.generate_report.report_generator import ReportGenerator
 
 logger = logging.getLogger(__name__)
 
-
-@click.group(cls=DefaultGroup)
-def generate_report() -> None:
-    """Ingest metadata into DataHub."""
-    pass
-
-
-@generate_report.command(default=True)
-def run(config: str) -> None:
-    """Ingest metadata into DataHub."""
+@click.command()
+@click.option(
+    "-c",
+    "--config",
+    type=click.Path(exists=True, dir_okay=False),
+    help="Config file in .toml or .yaml format.",
+    required=True,
+)
+def generate_report(config: str) -> None:
+    """Generate reports from DataHub."""
     logger.debug("DataHub CLI version: %s", datahub_package.nice_version_name())
 
     config_file = pathlib.Path(config)
-    pipeline_config = load_config_file(config_file)
+    config = load_config_file(config_file)
 
     try:
-        logger.debug(f"Using config: {pipeline_config}")
-        pipeline = Pipeline.create(pipeline_config)
+        logger.debug(f"Using config: {config}")
+        report_generator = ReportGenerator.create(config)
     except ValidationError as e:
         click.echo(e, err=True)
         sys.exit(1)
 
-    logger.info("Starting metadata generate_report")
-    logger.info(os.environ["S3_OUTPUT_PATH_ROOT"])
-    pipeline.run()
-    logger.info("Finished metadata generate_report")
-    ret = pipeline.pretty_print_summary()
+    logger.info("Starting generate report")
+    ret = report_generator.generate()
+    logger.info("Finished generate report")
     sys.exit(ret)

--- a/metadata-ingestion/tests/unit/report_generator/expected_basic.csv
+++ b/metadata-ingestion/tests/unit/report_generator/expected_basic.csv
@@ -1,0 +1,5 @@
+dataset,field,type,privacy_law
+stage_db.users.user,id,IDENTIFIER,"CCPA, GDPR"
+stage_db.users.user,full_name,PERSON,"CCPA, GDPR"
+stage_db.users.user,created,DATE,
+stage_db.users.user,updated,DATE,

--- a/metadata-ingestion/tests/unit/report_generator/expected_basic.csv
+++ b/metadata-ingestion/tests/unit/report_generator/expected_basic.csv
@@ -3,3 +3,4 @@ stage_db.users.user,id,IDENTIFIER,"CCPA, GDPR"
 stage_db.users.user,full_name,PERSON,"CCPA, GDPR"
 stage_db.users.user,created,DATE,
 stage_db.users.user,updated,DATE,
+stage_db.users.user,field_without_terms,,

--- a/metadata-ingestion/tests/unit/report_generator/test_report_generator.py
+++ b/metadata-ingestion/tests/unit/report_generator/test_report_generator.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import requests
 
@@ -13,57 +13,57 @@ from datahub.cli.generate_report.report_generator import (
 
 FIXTURES_PATH = os.path.dirname(__file__)
 
-class TestReportGenerator(TestCase):
 
+class TestReportGenerator(TestCase):
     def setUp(self):
         self.tmp_output_file = tempfile.NamedTemporaryFile()
         self.config = {
             "datahub_base_url": "http://localhost:1234",
-            "search_queries": ['*'],
+            "search_queries": ["*"],
             "output": {
                 "format": "csv",
-                "destination": {
-                    "filepath": self.tmp_output_file.name
-                },
+                "destinations": [
+                    {"filepath": self.tmp_output_file.name},
+                ],
             },
         }
 
     def tearDown(self):
         self.tmp_output_file.close()
 
-    @patch.object(datahub.cli.generate_report.report_generator, 'PrivacyTermExtractor')
+    @patch.object(datahub.cli.generate_report.report_generator, "PrivacyTermExtractor")
     def test_basic(self, mock_privacy_term_extractor_class):
         mock_extractor = MagicMock()
         mock_extractor.yield_search_results.return_value = [
             {
-                'dataset': 'stage_db.users.user',
-                'field': 'id',
-                'type': ['IDENTIFIER'],
-                'privacy_law': ['CCPA', 'GDPR'],
+                "dataset": "stage_db.users.user",
+                "field": "id",
+                "type": ["IDENTIFIER"],
+                "privacy_law": ["CCPA", "GDPR"],
             },
             {
-                'dataset': 'stage_db.users.user',
-                'field': 'full_name',
-                'type': ['PERSON'],
-                'privacy_law': ['CCPA', 'GDPR'],
+                "dataset": "stage_db.users.user",
+                "field": "full_name",
+                "type": ["PERSON"],
+                "privacy_law": ["CCPA", "GDPR"],
             },
             {
-                'dataset': 'stage_db.users.user',
-                'field': 'created',
-                'type': ['DATE'],
-                'privacy_law': [],
+                "dataset": "stage_db.users.user",
+                "field": "created",
+                "type": ["DATE"],
+                "privacy_law": [],
             },
             {
-                'dataset': 'stage_db.users.user',
-                'field': 'updated',
-                'type': ['DATE'],
-                'privacy_law': [],
+                "dataset": "stage_db.users.user",
+                "field": "updated",
+                "type": ["DATE"],
+                "privacy_law": [],
             },
             {
-                'dataset': 'stage_db.users.user',
-                'field': 'field_without_terms',
-                'type': [],
-                'privacy_law': [],
+                "dataset": "stage_db.users.user",
+                "field": "field_without_terms",
+                "type": [],
+                "privacy_law": [],
             },
         ]
         mock_privacy_term_extractor_class.return_value = mock_extractor
@@ -71,10 +71,14 @@ class TestReportGenerator(TestCase):
         rg = ReportGenerator.create(self.config)
         rg.generate()
 
-        mock_privacy_term_extractor_class.assert_called_once_with(self.config['datahub_base_url'])
-        mock_extractor.yield_search_results_assert_called_once_with(self.config['search_queries'])
+        mock_privacy_term_extractor_class.assert_called_once_with(
+            self.config["datahub_base_url"]
+        )
+        mock_extractor.yield_search_results_assert_called_once_with(
+            self.config["search_queries"]
+        )
 
-        with open(os.path.join(FIXTURES_PATH, 'expected_basic.csv'), 'rb') as f:
+        with open(os.path.join(FIXTURES_PATH, "expected_basic.csv"), "rb") as f:
             expected_lines = f.readlines()
 
         self.tmp_output_file.seek(0)
@@ -82,8 +86,8 @@ class TestReportGenerator(TestCase):
         for expected, actual in zip(expected_lines, actual_lines):
             self.assertEqual(expected.strip(), actual.strip())
 
-class TestPrivacyTermExtractor(TestCase):
 
+class TestPrivacyTermExtractor(TestCase):
     @patch.object(requests, "post")
     def test_yield_search_results(self, mock_post):
         mock_search_results = [
@@ -92,15 +96,9 @@ class TestPrivacyTermExtractor(TestCase):
                     "schemaMetadata": {
                         "name": "stage_db.users.user",
                         "fields": [
-                            {
-                                "fieldPath": "first_name",
-                                "glossaryTerms": None
-                            },
-                            {
-                                "fieldPath": "roles",
-                                "glossaryTerms": None
-                            }
-                        ]
+                            {"fieldPath": "first_name", "glossaryTerms": None},
+                            {"fieldPath": "roles", "glossaryTerms": None},
+                        ],
                     },
                     "editableSchemaMetadata": {
                         "editableSchemaFieldInfo": [
@@ -111,32 +109,32 @@ class TestPrivacyTermExtractor(TestCase):
                                         {
                                             "term": {
                                                 "urn": "urn:li:glossaryTerm:PrivacyLaw.PIPEDA",
-                                                "name": "PIPEDA"
+                                                "name": "PIPEDA",
                                             }
                                         },
                                         {
                                             "term": {
                                                 "urn": "urn:li:glossaryTerm:PrivacyLaw.CCPA",
-                                                "name": "CCPA"
+                                                "name": "CCPA",
                                             }
                                         },
                                         {
                                             "term": {
                                                 "urn": "urn:li:glossaryTerm:PiiData.PERSON",
-                                                "name": "PERSON"
+                                                "name": "PERSON",
                                             }
                                         },
                                         {
                                             "term": {
                                                 "urn": "urn:li:glossaryTerm:PiiData.NORP",
-                                                "name": "NORP"
+                                                "name": "NORP",
                                             }
-                                        }
+                                        },
                                     ]
-                                }
+                                },
                             }
                         ]
-                    }
+                    },
                 }
             },
             {
@@ -144,15 +142,9 @@ class TestPrivacyTermExtractor(TestCase):
                     "schemaMetadata": {
                         "name": "stage_db.some_schema.some_event_table",
                         "fields": [
-                            {
-                                "fieldPath": "event_id",
-                                "glossaryTerms": None
-                            },
-                            {
-                                "fieldPath": "event_time",
-                                "glossaryTerms": None
-                            }
-                        ]
+                            {"fieldPath": "event_id", "glossaryTerms": None},
+                            {"fieldPath": "event_time", "glossaryTerms": None},
+                        ],
                     },
                     "editableSchemaMetadata": {
                         "editableSchemaFieldInfo": [
@@ -163,23 +155,23 @@ class TestPrivacyTermExtractor(TestCase):
                                         {
                                             "term": {
                                                 "urn": "urn:li:glossaryTerm:PiiData.DATE",
-                                                "name": "DATE"
+                                                "name": "DATE",
                                             }
                                         }
                                     ]
-                                }
+                                },
                             }
                         ]
-                    }
+                    },
                 }
             },
         ]
         response1 = MagicMock()
         response1.json.return_value = {
-            'data': {
-                'search': {
-                    'total': len(mock_search_results),
-                    'searchResults': mock_search_results
+            "data": {
+                "search": {
+                    "total": len(mock_search_results),
+                    "searchResults": mock_search_results,
                 },
             },
         }
@@ -187,32 +179,104 @@ class TestPrivacyTermExtractor(TestCase):
 
         expected = [
             {
-                'dataset': 'stage_db.users.user',
-                'field': 'first_name',
-                'type': ['PERSON', 'NORP'],
-                'privacy_law': ['PIPEDA', 'CCPA'],
+                "dataset": "stage_db.users.user",
+                "field": "first_name",
+                "type": ["PERSON", "NORP"],
+                "privacy_law": ["PIPEDA", "CCPA"],
             },
             {
-                'dataset': 'stage_db.users.user',
-                'field': 'roles',
-                'type': [],
-                'privacy_law': [],
+                "dataset": "stage_db.users.user",
+                "field": "roles",
+                "type": [],
+                "privacy_law": [],
             },
             {
-                'dataset': 'stage_db.some_schema.some_event_table',
-                'field': 'event_id',
-                'type': [],
-                'privacy_law': [],
+                "dataset": "stage_db.some_schema.some_event_table",
+                "field": "event_id",
+                "type": [],
+                "privacy_law": [],
             },
             {
-                'dataset': 'stage_db.some_schema.some_event_table',
-                'field': 'event_time',
-                'type': ['DATE'],
-                'privacy_law': [],
+                "dataset": "stage_db.some_schema.some_event_table",
+                "field": "event_time",
+                "type": ["DATE"],
+                "privacy_law": [],
             },
         ]
-        extractor = PrivacyTermExtractor('http://localhost:1234')
+        extractor = PrivacyTermExtractor("http://localhost:1234")
 
-        actual = list(extractor.yield_search_results(['snowflake']))
+        actual = list(extractor.yield_search_results(["snowflake"]))
         mock_post.assert_called_once()
         self.assertListEqual(expected, actual)
+
+    @patch.object(requests, "post")
+    def test_yield_search_results__pagination(self, mock_post):
+        def _make_entity(i):
+            return {
+                "entity": {
+                    "schemaMetadata": {
+                        "name": f"stage_db.some_schema.some_table_{i}",
+                        "fields": [
+                            {"fieldPath": "field1", "glossaryTerms": None},
+                            {"fieldPath": "field2", "glossaryTerms": None},
+                        ],
+                    },
+                    "editableSchemaMetadata": None,
+                }
+            }
+
+        mock_search_results1 = [_make_entity(i) for i in range(0, 10)]
+        mock_search_results2 = [_make_entity(i) for i in range(10, 17)]
+        num_mock_datasets = len(mock_search_results1) + len(mock_search_results2)
+        response1 = MagicMock()
+        response1.json.return_value = {
+            "data": {
+                "search": {
+                    "total": num_mock_datasets,
+                    "searchResults": mock_search_results1,
+                },
+            },
+        }
+        response2 = MagicMock()
+        response2.json.return_value = {
+            "data": {
+                "search": {
+                    "total": num_mock_datasets,
+                    "searchResults": mock_search_results2,
+                },
+            },
+        }
+        mock_post.side_effect = [response1, response2]
+
+        extractor = PrivacyTermExtractor(
+            "http://localhost:1234", search_query_page_size=10
+        )
+        actual = list(extractor.yield_search_results(["snowflake"]))
+        mock_post.assert_has_calls(
+            [
+                call(
+                    "http://localhost:1234/api/graphql",
+                    json={
+                        "query": extractor.GRAPHQL_QUERY,
+                        "variables": {
+                            "search_query": "snowflake",
+                            "page_size": 10,
+                            "offset": 0,
+                        },
+                    },
+                ),
+                call(
+                    "http://localhost:1234/api/graphql",
+                    json={
+                        "query": extractor.GRAPHQL_QUERY,
+                        "variables": {
+                            "search_query": "snowflake",
+                            "page_size": 10,
+                            "offset": 10,
+                        },
+                    },
+                ),
+            ]
+        )
+        num_mock_fields_per_dataset = 2
+        self.assertEqual(len(actual), num_mock_datasets * num_mock_fields_per_dataset)

--- a/metadata-ingestion/tests/unit/report_generator/test_report_generator.py
+++ b/metadata-ingestion/tests/unit/report_generator/test_report_generator.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import requests
 
+import datahub.cli.generate_report.report_generator
 from datahub.cli.generate_report.report_generator import (
     PrivacyTermExtractor,
     ReportGenerator,
@@ -30,7 +31,7 @@ class TestReportGenerator(TestCase):
     def tearDown(self):
         self.tmp_output_file.close()
 
-    @patch('datahub.cli.generate_report.report_generator.PrivacyTermExtractor')
+    @patch.object(datahub.cli.generate_report.report_generator, 'PrivacyTermExtractor')
     def test_basic(self, mock_privacy_term_extractor_class):
         mock_extractor = MagicMock()
         mock_extractor.yield_search_results.return_value = [

--- a/metadata-ingestion/tests/unit/report_generator/test_report_generator.py
+++ b/metadata-ingestion/tests/unit/report_generator/test_report_generator.py
@@ -54,6 +54,12 @@ class TestReportGenerator(TestCase):
                 'type': ['DATE'],
                 'privacy_law': [],
             },
+            {
+                'dataset': 'stage_db.users.user',
+                'field': 'field_without_terms',
+                'type': [],
+                'privacy_law': [],
+            },
         ]
         mock_privacy_term_extractor_class.return_value = mock_extractor
 
@@ -64,7 +70,9 @@ class TestReportGenerator(TestCase):
         mock_extractor.yield_search_results_assert_called_once_with(self.config['search_queries'])
 
         with open(os.path.join(FIXTURES_PATH, 'expected_basic.csv'), 'rb') as f:
-            actual_lines = f.readlines()
+            expected_lines = f.readlines()
+
         self.tmp_output_file.seek(0)
-        for expected, actual in zip(self.tmp_output_file.readlines(), actual_lines):
+        actual_lines = self.tmp_output_file.readlines()
+        for expected, actual in zip(expected_lines, actual_lines):
             self.assertEqual(expected.strip(), actual.strip())

--- a/metadata-ingestion/tests/unit/report_generator/test_report_generator.py
+++ b/metadata-ingestion/tests/unit/report_generator/test_report_generator.py
@@ -1,0 +1,70 @@
+import os
+import tempfile
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+from datahub.cli.generate_report.report_generator import ReportGenerator
+
+
+FIXTURES_PATH = os.path.dirname(__file__)
+
+class TestReportGenerator(TestCase):
+
+    def setUp(self):
+        self.tmp_output_file = tempfile.NamedTemporaryFile()
+        self.config = {
+            "datahub_base_url": "http://localhost:1234",
+            "search_queries": ['*'],
+            "output": {
+                "format": "csv",
+                "destination": {
+                    "filepath": self.tmp_output_file.name
+                },
+            },
+        }
+
+    def tearDown(self):
+        self.tmp_output_file.close()
+
+    @patch('datahub.cli.generate_report.report_generator.PrivacyTermExtractor')
+    def test_basic(self, mock_privacy_term_extractor_class):
+        mock_extractor = MagicMock()
+        mock_extractor.yield_search_results.return_value = [
+            {
+                'dataset': 'stage_db.users.user',
+                'field': 'id',
+                'type': ['IDENTIFIER'],
+                'privacy_law': ['CCPA', 'GDPR'],
+            },
+            {
+                'dataset': 'stage_db.users.user',
+                'field': 'full_name',
+                'type': ['PERSON'],
+                'privacy_law': ['CCPA', 'GDPR'],
+            },
+            {
+                'dataset': 'stage_db.users.user',
+                'field': 'created',
+                'type': ['DATE'],
+                'privacy_law': [],
+            },
+            {
+                'dataset': 'stage_db.users.user',
+                'field': 'updated',
+                'type': ['DATE'],
+                'privacy_law': [],
+            },
+        ]
+        mock_privacy_term_extractor_class.return_value = mock_extractor
+
+        rg = ReportGenerator.create(self.config)
+        rg.generate()
+
+        mock_privacy_term_extractor_class.assert_called_once_with(self.config['datahub_base_url'])
+        mock_extractor.yield_search_results_assert_called_once_with(self.config['search_queries'])
+
+        with open(os.path.join(FIXTURES_PATH, 'expected_basic.csv'), 'rb') as f:
+            actual_lines = f.readlines()
+        self.tmp_output_file.seek(0)
+        for expected, actual in zip(self.tmp_output_file.readlines(), actual_lines):
+            self.assertEqual(expected.strip(), actual.strip())


### PR DESCRIPTION
**How it works**
Able to run "search query"s against DataHub's graphql API, then it transforms the glossary terms into something like below, format wise will be changeable, currently hardcoded to look at `PiiData` and `PrivacyLaw` terms and displays them to the respective columns.
```
dataset,field,type,privacy_law
stage_db.users.user,id,IDENTIFIER,"CCPA, GDPR"
```

sample usage: `❯ datahub generate-report -c generate_report_config.yaml`
sample `generate_report_config.yaml`:
```
datahub_base_url: http://localhost:8080
search_queries:
  - snowflake
output:
  format: csv
  destinations:
    - filepath: snowflake_catalog.csv
    - s3_bucket: <bucket>
      s3_key: datahub/reports/datasets_catalog/%Y/%m/%d/snowflake_catalog.csv
```

sample logs:
```
❯ datahub generate-report -c report.yaml
[2021-12-10 12:13:10,152] INFO     {datahub.cli.generate_report_cli:37} - Starting generate report
[2021-12-10 12:13:10,153] INFO     {datahub.cli.generate_report.report_generator:115} - Issuing graphql queries with variables: {'search_query': 'snowflake', 'page_size': 500, 'offset': 0}
[2021-12-10 12:13:12,962] INFO     {datahub.cli.generate_report.report_generator:115} - Issuing graphql queries with variables: {'search_query': 'snowflake', 'page_size': 500, 'offset': 500}
[2021-12-10 12:13:15,575] INFO     {datahub.cli.generate_report.report_generator:115} - Issuing graphql queries with variables: {'search_query': 'snowflake', 'page_size': 500, 'offset': 1000}
[2021-12-10 12:13:17,488] INFO     {datahub.cli.generate_report.report_generator:245} - Uploading /var/folders/zs/by77rc_s0hjg804_tf55_z600000gn/T/tmpabl1h54a to s3://our-s3-bucket/datahub/reports/datasets_catalog/2021/12/10/snowflake_catalog.csv
[2021-12-10 12:13:24,957] INFO     {datahub.cli.generate_report_cli:39} - Finished generate report
```


```
❯ datahub generate-report -c report.yaml
[2021-12-10 12:18:22,540] INFO     {datahub.cli.generate_report_cli:37} - Starting generate report
[2021-12-10 12:18:22,541] INFO     {datahub.cli.generate_report.report_generator:116} - Issuing graphql query with variables: {'search_query': 'snowflake', 'page_size': 500, 'offset': 0}
[2021-12-10 12:18:25,162] INFO     {datahub.cli.generate_report.report_generator:116} - Issuing graphql query with variables: {'search_query': 'snowflake', 'page_size': 500, 'offset': 500}
[2021-12-10 12:18:27,449] INFO     {datahub.cli.generate_report.report_generator:116} - Issuing graphql query with variables: {'search_query': 'snowflake', 'page_size': 500, 'offset': 1000}
[2021-12-10 12:18:29,177] INFO     {datahub.cli.generate_report.report_generator:228} - Output at: /Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/snowflake_catalog.csv
[2021-12-10 12:18:29,177] INFO     {datahub.cli.generate_report_cli:39} - Finished generate report
```