### PR TITLE
Create SampleableStatefulIngestionSourceBase to be used to fix upgrade issues

### DIFF
--- a/metadata-ingestion/src/datahub/classification/classifier.py
+++ b/metadata-ingestion/src/datahub/classification/classifier.py
@@ -8,7 +8,9 @@ import spacy
 
 from datahub.classification.privacy.privacy.api import PIIEngine
 from datahub.ingestion.api.common import RecordEnvelope
-from datahub.ingestion.api.sampleable_source import SampleableSource
+from datahub.ingestion.source.state.sampleable_stateful_ingestion_base import (
+    SampleableStatefulIngestionSourceBase,
+)
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -23,9 +25,9 @@ class ClassificationResult:
 
 
 class Classifier:
-    sampler: SampleableSource
+    sampler: SampleableStatefulIngestionSourceBase
 
-    def __init__(self, sampler: SampleableSource):
+    def __init__(self, sampler: SampleableStatefulIngestionSourceBase):
         self.sampler = sampler
         # TODO https://jira.team.affirm.com/browse/DF-1737
         self.engine = PIIEngine()

--- a/metadata-ingestion/src/datahub/classification/classifier_pipeline.py
+++ b/metadata-ingestion/src/datahub/classification/classifier_pipeline.py
@@ -13,11 +13,13 @@ import requests
 from datahub.classification.classifier import ClassificationResult, Classifier
 from datahub.configuration.common import ConfigModel, DynamicTypedConfig
 from datahub.ingestion.api.common import PipelineContext, RecordEnvelope
-from datahub.ingestion.api.sampleable_source import SampleableSource
 from datahub.ingestion.api.source import Extractor
 from datahub.ingestion.api.transform import Transformer
 from datahub.ingestion.extractor.extractor_registry import extractor_registry
 from datahub.ingestion.source.source_registry import source_registry
+from datahub.ingestion.source.state.sampleable_stateful_ingestion_base import (
+    SampleableStatefulIngestionSourceBase,
+)
 from datahub.ingestion.transformer.transform_registry import transform_registry
 from datahub.metadata.schema_classes import SchemaMetadataClass
 from datahub.utilities.metrics import DatahubCustomMetric, DatahubCustomMetricReporter
@@ -54,7 +56,7 @@ class ClassifierPipeline:
     my_shard_id: int
     num_shards: int
     num_worker_threads: int
-    source: SampleableSource
+    source: SampleableStatefulIngestionSourceBase
     transformers: List[Transformer]
 
     ddb_client: Any
@@ -71,7 +73,7 @@ class ClassifierPipeline:
         self.ctx = PipelineContext(run_id=str(uuid.uuid1()))
         source_type = self.config.source.type
         source_class = source_registry.get(source_type)
-        self.source: SampleableSource = source_class.create(
+        self.source: SampleableStatefulIngestionSourceBase = source_class.create(
             self.config.source.dict().get("config", {}), self.ctx
         )
         self.extractor_class = extractor_registry.get(self.config.source.extractor)

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
@@ -30,12 +30,14 @@ from datahub.emitter.mce_builder import (
 )
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.common import PipelineContext, RecordEnvelope
-from datahub.ingestion.api.sampleable_source import SampleableSource
 from datahub.ingestion.api.source import SourceReport
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.state.checkpoint import Checkpoint
 from datahub.ingestion.source.state.sql_common_state import (
     BaseSQLAlchemyCheckpointState,
+)
+from datahub.ingestion.source.state.sampleable_stateful_ingestion_base import (
+    SampleableStatefulIngestionSourceBase,
 )
 from datahub.ingestion.source.state.stateful_ingestion_base import (
     JobId,
@@ -350,7 +352,7 @@ def get_schema_metadata(
     return schema_metadata
 
 
-class SQLAlchemySource(SampleableSource):
+class SQLAlchemySource(SampleableStatefulIngestionSourceBase):
     """A Base class for all SQL Sources that use SQLAlchemy to extend"""
 
     def __init__(self, config: SQLAlchemyConfig, ctx: PipelineContext, platform: str):

--- a/metadata-ingestion/src/datahub/ingestion/source/state/sampleable_stateful_ingestion_base.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/sampleable_stateful_ingestion_base.py
@@ -2,12 +2,12 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from typing import Iterable
 
-from datahub.ingestion.api.source import Source
+from datahub.ingestion.source.state.stateful_ingestion_base import StatefulIngestionSourceBase
 
 
 # See https://github.com/python/mypy/issues/5374 for why we suppress this mypy error.
 @dataclass  # type: ignore[misc]
-class SampleableSource(Source):
+class SampleableStatefulIngestionSourceBase(StatefulIngestionSourceBase):
     @abstractmethod
     def sample(self, schema_name: str) -> Iterable[str]:
         pass

--- a/metadata-ingestion/tests/unit/test_classification_pipeline.py
+++ b/metadata-ingestion/tests/unit/test_classification_pipeline.py
@@ -11,10 +11,12 @@ from botocore.stub import Stubber
 
 from datahub.classification.classifier_pipeline import ClassifierPipeline
 from datahub.ingestion.api.common import PipelineContext, RecordEnvelope, WorkUnit
-from datahub.ingestion.api.sampleable_source import SampleableSource
 from datahub.ingestion.api.source import Source, SourceReport
 from datahub.ingestion.api.transform import Transformer
 from datahub.ingestion.api.workunit import MetadataWorkUnit
+from datahub.ingestion.source.state.sampleable_stateful_ingestion_base import (
+    SampleableStatefulIngestionSourceBase,
+)
 from datahub.metadata.com.linkedin.pegasus2avro.common import Status
 from datahub.metadata.com.linkedin.pegasus2avro.mxe import SystemMetadata
 from datahub.metadata.schema_classes import (
@@ -402,7 +404,7 @@ class AddStatusRemovedTransformer(Transformer):
             yield record_envelope
 
 
-class FakeSingleSourceWithPii(SampleableSource):
+class FakeSingleSourceWithPii(SampleableStatefulIngestionSourceBase):
     def __init__(self):
         self.source_report = SourceReport()
         self.work_units: List[MetadataWorkUnit] = [
@@ -430,7 +432,7 @@ class FakeSingleSourceWithPii(SampleableSource):
         pass
 
 
-class FakeMultiSourceWithPii(SampleableSource):
+class FakeMultiSourceWithPii(SampleableStatefulIngestionSourceBase):
     def __init__(self):
         self.source_report = SourceReport()
         self.work_units: List[MetadataWorkUnit] = [
@@ -459,7 +461,7 @@ class FakeMultiSourceWithPii(SampleableSource):
         pass
 
 
-class FakeSingleSourceWithoutPii(SampleableSource):
+class FakeSingleSourceWithoutPii(SampleableStatefulIngestionSourceBase):
     def __init__(self):
         self.source_report = SourceReport()
         self.work_units: List[MetadataWorkUnit] = [


### PR DESCRIPTION
After upgrading from 0.8.15 to 0.8.23, ingestion stopped working due to some of our forked changes.

After this PR, we get the same error as without this change. see exception below. 

```
❯ datahub ingest -c snowflake.yaml --preview

File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/src/datahub/entrypoints.py", line 105, in main
    sys.exit(datahub(standalone_mode=False, **kwargs))
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/.venv/lib/python3.9/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/.venv/lib/python3.9/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/.venv/lib/python3.9/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/.venv/lib/python3.9/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/.venv/lib/python3.9/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/.venv/lib/python3.9/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/src/datahub/telemetry/telemetry.py", line 146, in wrapper
    res = func(*args, **kwargs)
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/src/datahub/cli/ingest_cli.py", line 76, in run
    pipeline = Pipeline.create(pipeline_config, dry_run, preview)
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/src/datahub/ingestion/run/pipeline.py", line 150, in create
    return cls(config, dry_run=dry_run, preview_mode=preview_mode)
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/src/datahub/ingestion/run/pipeline.py", line 116, in __init__
    self.source: Source = source_class.create(
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/src/datahub/ingestion/source/sql/snowflake.py", line 112, in create
    return cls(config, ctx)
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/src/datahub/ingestion/source/sql/snowflake.py", line 106, in __init__
    super().__init__(config, ctx, "snowflake")
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py", line 359, in __init__
    super(SQLAlchemySource, self).__init__(config, ctx)

TypeError: __init__() takes 2 positional arguments but 3 were given
```


Alternatively #12 works