### PR TITLE
Override to SampleableSource instead of Source for stateful ingestion

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
@@ -350,7 +350,7 @@ def get_schema_metadata(
     return schema_metadata
 
 
-class SQLAlchemySource(SampleableSource):
+class SQLAlchemySource(StatefulIngestionSourceBase):
     """A Base class for all SQL Sources that use SQLAlchemy to extend"""
 
     def __init__(self, config: SQLAlchemyConfig, ctx: PipelineContext, platform: str):

--- a/metadata-ingestion/src/datahub/ingestion/source/state/stateful_ingestion_base.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/stateful_ingestion_base.py
@@ -10,6 +10,7 @@ from datahub.configuration.common import (
 )
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.ingestion_state_provider import IngestionStateProvider, JobId
+from datahub.ingestion.api.sampleable_source import SampleableSource
 from datahub.ingestion.api.source import Source
 from datahub.ingestion.source.state.checkpoint import Checkpoint, CheckpointStateBase
 from datahub.ingestion.source.state_provider.datahub_ingestion_state_provider import (
@@ -54,7 +55,7 @@ class StatefulIngestionConfigBase(ConfigModel):
     stateful_ingestion: Optional[StatefulIngestionConfig] = None
 
 
-class StatefulIngestionSourceBase(Source):
+class StatefulIngestionSourceBase(SampleableSource):
     """
     Defines the base class for all stateful sources.
     """


### PR DESCRIPTION
**Problem**
upstream 0.8.15 to 0.8.23 introduced 
```
class SQLAlchemySource(StatefulIngestionSourceBase):
```
from
```
class SQLAlchemySource(Source):
```

but in 0.8.15 we forked to
```
class SQLAlchemySource(SampleableSource):
```

So our code of `SQLAlchemySource` needs to have the functionality of `StatefulIngestionSourceBase` while still having the `sample` function for classification logic.

The error we get when running ingestion is 
```
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/src/datahub/entrypoints.py", line 105, in main
    sys.exit(datahub(standalone_mode=False, **kwargs))
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/.venv/lib/python3.9/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/.venv/lib/python3.9/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/.venv/lib/python3.9/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/.venv/lib/python3.9/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/.venv/lib/python3.9/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/.venv/lib/python3.9/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/src/datahub/telemetry/telemetry.py", line 146, in wrapper
    res = func(*args, **kwargs)
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/src/datahub/cli/ingest_cli.py", line 76, in run
    pipeline = Pipeline.create(pipeline_config, dry_run, preview)
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/src/datahub/ingestion/run/pipeline.py", line 150, in create
    return cls(config, dry_run=dry_run, preview_mode=preview_mode)
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/src/datahub/ingestion/run/pipeline.py", line 116, in __init__
    self.source: Source = source_class.create(
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/src/datahub/ingestion/source/sql/snowflake.py", line 112, in create
    return cls(config, ctx)
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/src/datahub/ingestion/source/sql/snowflake.py", line 106, in __init__
    super().__init__(config, ctx, "snowflake")
File "/Users/nicholaswu/src/github.com/Affirm/datahub/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py", line 357, in __init__
    super(SQLAlchemySource, self).__init__(config, ctx)

TypeError: __init__() takes 2 positional arguments but 3 were given
```


**Solution** 
Update `StatefulIngestionSourceBase(SampleableSource)` instead of `StatefulIngestionSourceBase(Source)`

`❯ datahub ingest -c snowflake.yaml --preview` works again.

**Other notes**
Tried other ways of overriding which didn't work: https://github.com/Affirm/datahub/pull/11