### PR TITLE
bug(report-generator): handle empty schemaMetadata

### DIFF
--- a/metadata-ingestion/src/datahub/cli/generate_report/report_generator.py
+++ b/metadata-ingestion/src/datahub/cli/generate_report/report_generator.py
@@ -142,15 +142,17 @@ class PrivacyTermExtractor:
     def _yield_rows(cls, entity: Dict) -> Generator[Dict, None, None]:
         # Merge glossaryTerms from both schemaMetadata and editableSchemaMetadata
         merged_rows = {}
-        # schemaMetadata will contain all fields
-        for field in entity["entity"]["schemaMetadata"]["fields"]:
-            merged_rows[field["fieldPath"]] = {
-                "dataset": entity["entity"]["schemaMetadata"]["name"],
-                "field": field["fieldPath"],
-                "type": [],
-                "privacy_law": [],
-            }
-            cls._add_terms_to_row(merged_rows[field["fieldPath"]], field)
+        # schemaMetadata can be empty
+        if entity["entity"]["schemaMetadata"]:
+            # schemaMetadata will contain all fields
+            for field in entity["entity"]["schemaMetadata"]["fields"]:
+                merged_rows[field["fieldPath"]] = {
+                    "dataset": entity["entity"]["schemaMetadata"]["name"],
+                    "field": field["fieldPath"],
+                    "type": [],
+                    "privacy_law": [],
+                }
+                cls._add_terms_to_row(merged_rows[field["fieldPath"]], field)
 
         # editableSchemaMetadata can be empty or contain subset of fields
         if entity["entity"]["editableSchemaMetadata"]:

--- a/metadata-ingestion/src/datahub/cli/generate_report/report_generator.py
+++ b/metadata-ingestion/src/datahub/cli/generate_report/report_generator.py
@@ -142,7 +142,7 @@ class PrivacyTermExtractor:
     def _yield_rows(cls, entity: Dict) -> Generator[Dict, None, None]:
         # Merge glossaryTerms from both schemaMetadata and editableSchemaMetadata
         merged_rows = {}
-        # schemaMetadata can be empty
+        # schemaMetadata can be empty due to the zombie issue. Let's not fail here.
         if entity["entity"]["schemaMetadata"]:
             # schemaMetadata will contain all fields
             for field in entity["entity"]["schemaMetadata"]["fields"]:

--- a/metadata-ingestion/tests/unit/report_generator/test_report_generator.py
+++ b/metadata-ingestion/tests/unit/report_generator/test_report_generator.py
@@ -280,3 +280,31 @@ class TestPrivacyTermExtractor(TestCase):
         )
         num_mock_fields_per_dataset = 2
         self.assertEqual(len(actual), num_mock_datasets * num_mock_fields_per_dataset)
+
+    @patch.object(requests, "post")
+    def test_yield_search_results__empty_schema_metadata(self, mock_post):
+        mock_search_results = [
+            {
+                "entity": {
+                    "schemaMetadata": None,
+                    "editableSchemaMetadata": None,
+                }
+            },
+        ]
+        response1 = MagicMock()
+        response1.json.return_value = {
+            "data": {
+                "search": {
+                    "total": len(mock_search_results),
+                    "searchResults": mock_search_results,
+                },
+            },
+        }
+        mock_post.side_effect = [response1]
+
+        expected = []
+        extractor = PrivacyTermExtractor("http://localhost:1234")
+
+        actual = list(extractor.yield_search_results(["snowflake"]))
+        mock_post.assert_called_once()
+        self.assertListEqual(expected, actual)


### PR DESCRIPTION
Schema metadata can be empty for e.g. Snowflake external tables, not sure if it's a datahub ingestion issue or not, but this fixes the report generator.

EDIT: actually let me look into the empty schemaMetadata issue, I think it might be a bug, as in it shouldn't ever be empty.

**Test Plan**
Ran report generator locally against port-forwarded stage and prod instances. Both works. 

<details>
<summary>Unit test fails before changes</summary>

```
________________________________________________________________________________ TestPrivacyTermExtractor.test_yield_search_results__empty_schema_metadata _________________________________________________________________________________

self = <test_report_generator.TestPrivacyTermExtractor testMethod=test_yield_search_results__empty_schema_metadata>, mock_post = <MagicMock name='post' id='4761813392'>

    @patch.object(requests, "post")
    def test_yield_search_results__empty_schema_metadata(self, mock_post):
        mock_search_results = [
            {
                "entity": {
                    "schemaMetadata": None,
                    "editableSchemaMetadata": None,
                }
            },
        ]
        response1 = MagicMock()
        response1.json.return_value = {
            "data": {
                "search": {
                    "total": len(mock_search_results),
                    "searchResults": mock_search_results,
                },
            },
        }
        mock_post.side_effect = [response1]

        expected = []
        extractor = PrivacyTermExtractor("http://localhost:1234")

>       actual = list(extractor.yield_search_results(["snowflake"]))

tests/unit/report_generator/test_report_generator.py:308:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

cls = <class 'datahub.cli.generate_report.report_generator.PrivacyTermExtractor'>, entity = {'entity': {'editableSchemaMetadata': None, 'schemaMetadata': None}}

    @classmethod
    def _yield_rows(cls, entity: Dict) -> Generator[Dict, None, None]:
        # Merge glossaryTerms from both schemaMetadata and editableSchemaMetadata
        merged_rows = {}
        # schemaMetadata will contain all fields
>       for field in entity["entity"]["schemaMetadata"]["fields"]:
E       TypeError: 'NoneType' object is not subscriptable

src/datahub/cli/generate_report/report_generator.py:146: TypeError
```

</details>