### PR TITLE
Add custom ingestion source for artifacts

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -383,6 +383,7 @@ entry_points = {
     "console_scripts": ["datahub = datahub.entrypoints:main"],
     "datahub.ingestion.source.plugins": [
         "file = datahub.ingestion.source.file:GenericFileSource",
+        "affirm-artifact = datahub.ingestion.source.affirm_artifact:AffirmArtifactSource",
         "sqlalchemy = datahub.ingestion.source.sql.sql_generic:SQLAlchemyGenericSource",
         "athena = datahub.ingestion.source.sql.athena:AthenaSource",
         "azure-ad = datahub.ingestion.source.identity.azure_ad:AzureADSource",

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -245,6 +245,7 @@ plugins: Dict[str, Set[str]] = {
     "starburst-trino-usage": sql_common | usage_common | trino,
     "nifi": {"requests", "packaging"},
     "powerbi": {"orderedset"} | microsoft_common,
+    "affirm-artifact": {"ruamel.yaml>=0.17,<0.18"}
 }
 
 all_exclude_plugins: Set[str] = {
@@ -383,7 +384,6 @@ entry_points = {
     "console_scripts": ["datahub = datahub.entrypoints:main"],
     "datahub.ingestion.source.plugins": [
         "file = datahub.ingestion.source.file:GenericFileSource",
-        "affirm-artifact = datahub.ingestion.source.affirm_artifact:AffirmArtifactSource",
         "sqlalchemy = datahub.ingestion.source.sql.sql_generic:SQLAlchemyGenericSource",
         "athena = datahub.ingestion.source.sql.athena:AthenaSource",
         "azure-ad = datahub.ingestion.source.identity.azure_ad:AzureADSource",
@@ -429,6 +429,7 @@ entry_points = {
         "nifi = datahub.ingestion.source.nifi:NifiSource",
         "powerbi = datahub.ingestion.source.powerbi:PowerBiDashboardSource",
         "presto-on-hive = datahub.ingestion.source.sql.presto_on_hive:PrestoOnHiveSource",
+        "affirm-artifact = datahub.ingestion.source.affirm.artifact:AffirmArtifactSource",
     ],
     "datahub.ingestion.sink.plugins": [
         "file = datahub.ingestion.sink.file:FileSink",

--- a/metadata-ingestion/src/datahub/ingestion/source/affirm/artifact.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/affirm/artifact.py
@@ -28,26 +28,28 @@ class AffirmArtifact:
     description: str
     owner: str
     privacy_entrypoint: str
-    retention_days: int
+    retention_days: str
     processing_purposes: Sequence[str]
 
     def __post_init__(self):
         if self.privacy_entrypoint is None:
             self.privacy_entrypoint = ''
-        if self.retention_days is None:
-            self.retention_days = -1
         if self.processing_purposes is None:
             self.processing_purposes = []
 
 
 class AffirmArtifactSourceConfig(ConfigModel):
+    ''' TODO support git repo to automate the whole process: 
+    git clone, locate artifact and ingest
+    '''
     directory: str
-    filename: str
     platform: str
     env: str
 
 
 def iterate_artifact(directory: str) -> Iterable[AffirmArtifact]:
+    def fix_description(description: str):
+        return ' '.join(description.split())
     for r, _, filenames in os.walk(directory):
         for filename in filenames:
             if filename.endswith('.yaml'):
@@ -56,10 +58,10 @@ def iterate_artifact(directory: str) -> Iterable[AffirmArtifact]:
                     content = yaml.load(f)
                     artifact = AffirmArtifact(
                         name=filename.replace('.yaml', ''),
-                        description=content.get('description', ''),
+                        description=fix_description(content.get('description', '')),
                         owner=content.get('owner', ''),
                         privacy_entrypoint=content.get('privacy_entrypoint', ''),
-                        retention_days=content.get('retention_days', -1),
+                        retention_days=str(content.get('retention_days')) if content.get('retention_days') else '',
                         processing_purposes=content.get('processing_purposes', [])
                     )
                     yield artifact

--- a/metadata-ingestion/src/datahub/ingestion/source/affirm_artifact.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/affirm_artifact.py
@@ -1,0 +1,122 @@
+import sys
+import os
+import logging
+from dataclasses import dataclass, field
+from typing import Iterable
+from ruamel.yaml import YAML
+
+import datahub.emitter.mce_builder as builder
+from datahub.configuration.common import ConfigModel
+from datahub.ingestion.api.source import Source, SourceReport
+from datahub.ingestion.api.workunit import MetadataWorkUnit
+from datahub.metadata.com.linkedin.pegasus2avro.mxe import MetadataChangeEvent
+from datahub.metadata.com.linkedin.pegasus2avro.metadata.snapshot import DatasetSnapshot
+from datahub.metadata.schema_classes import (
+    DatasetPropertiesClass,
+    OwnerClass,
+    OwnershipClass,
+    OwnershipTypeClass,
+)
+
+
+logging.basicConfig(stream=sys.stderr, level=logging.INFO)
+yaml = YAML(typ='rt')
+
+
+@dataclass
+class AffirmArtifact:
+    name: str
+    description: str
+    owner: str
+    privacy_entrypoint: str
+    retention_days: int
+
+    def __post_init__(self):
+        if self.privacy_entrypoint is None:
+            self.privacy_entrypoint = ''
+        if self.retention_days is None:
+            self.retention_days = -1
+
+
+class AffirmArtifactSourceConfig(ConfigModel):
+    directory: str
+    filename: str
+    platform: str
+    env: str
+
+
+def iterate_artifact(directory: str) -> Iterable[AffirmArtifact]:
+    for r, _, filenames in os.walk(directory):
+        for filename in filenames:
+            if filename.endswith('.yaml'):
+                filepath = os.path.join(r, filename)
+                with open(filepath, 'r') as f:
+                    content = yaml.load(f)
+                    artifact = AffirmArtifact(
+                        name=filename.replace('.yaml', ''),
+                        description=content.get('description', ''),
+                        owner=content.get('owner', ''),
+                        privacy_entrypoint=content.get('privacy_entrypoint', ''),
+                        retention_days=content.get('retention_days', ''),
+                    )
+                    yield artifact
+
+
+def make_groupname(team: str) -> str:
+    prefix = "teams/"
+    if team.startswith(prefix):
+        team = team[len(prefix):]
+    dot_delimited = ".".join(reversed(team.split("/")))
+    camel_case = dot_delimited.replace("_", " ").title().replace(" ", "")
+    return f'{camel_case}.Team'
+
+
+@dataclass
+class AffirmArtifactSource(Source):
+    config: AffirmArtifactSourceConfig 
+    report: SourceReport = field(default_factory=SourceReport)
+
+    @classmethod
+    def create(cls, config_dict, ctx):
+        config = AffirmArtifactSourceConfig.parse_obj(config_dict)
+        return cls(ctx, config)
+
+    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
+        directory = self.config.directory
+        platform = self.config.platform
+        env = self.config.env
+        for artifact in iterate_artifact(directory):
+            dataset_name = artifact.name
+            logging.info(f'> Processing dataset {dataset_name}')
+            dataset_urn = builder.make_dataset_urn(platform, dataset_name, env)
+            dataset_snapshot = DatasetSnapshot(
+                urn=dataset_urn,
+                aspects=[],
+            )
+            dataset_properties = DatasetPropertiesClass(
+                description=artifact.description,
+                tags=[],
+                customProperties={
+                    'privacy_entrypoint': artifact.privacy_entrypoint,
+                    'retention_days': f'{artifact.retention_days}'
+                }
+            )
+            dataset_snapshot.aspects.append(dataset_properties)
+            ownership = OwnershipClass(
+                owners=[
+                    OwnerClass(
+                        owner= builder.make_group_urn(make_groupname(artifact.owner)),
+                        type=OwnershipTypeClass.DATAOWNER
+                    )
+                ]
+            )
+            dataset_snapshot.aspects.append(ownership)
+            mce = MetadataChangeEvent(proposedSnapshot=dataset_snapshot)
+            wu = MetadataWorkUnit(id=dataset_name, mce=mce)
+            yield wu
+
+    def get_report(self):
+        return self.report
+
+    def close(self):
+        pass


### PR DESCRIPTION
Sample recipe
```
source:
    type: affirm-artifact
    config:
        directory: 'path-to-artifact-directory'
        platform: 'affirm-3rd-party'
        env: 'PROD'

sink:
    type: 'datahub-rest'
    config:
        server: 'http://localhost:8080'
```

<img width="480" alt="Screen Shot 2022-07-29 at 9 27 12 PM" src="https://user-images.githubusercontent.com/107569566/181872316-2f17da79-9522-46a0-8c13-6ead47fe534e.png">



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)