### PR TITLE
Dynamodb ingestion

### DIFF
--- a/metadata-ingestion/examples/mce_files/dynamodb.json
+++ b/metadata-ingestion/examples/mce_files/dynamodb.json
@@ -1,0 +1,22 @@
+[
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DataPlatformSnapshot": {
+        "urn": "urn:li:dataPlatform:dynamodb",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataplatform.DataPlatformInfo": {
+              "datasetNameDelimiter": "/",
+              "name": "dynamodb",
+              "displayName": "DynamoDB",
+              "type": "KEY_VALUE_STORE",
+              "logoUrl": "https://www.pngkey.com/png/full/246-2467352_aws-dynamodb-logo-png-transparent-aws-dynamodb-logo.png"
+            }
+          }
+        ]
+      }
+    },
+    "proposedDelta": null
+  }
+]

--- a/metadata-ingestion/examples/recipes/dynamodb_platform.yml
+++ b/metadata-ingestion/examples/recipes/dynamodb_platform.yml
@@ -1,0 +1,9 @@
+source:
+    type: file
+    config:
+        filename: '../mce_files/dynamodb.json'
+
+sink:
+    type: 'datahub-rest'
+    config:
+        server: 'http://localhost:8080'

--- a/metadata-ingestion/examples/recipes/dynamodb_to_datahub.yml
+++ b/metadata-ingestion/examples/recipes/dynamodb_to_datahub.yml
@@ -1,0 +1,14 @@
+source:
+    type: dynamodb
+    config:
+        platform: 'dynamodb'
+        env: 'PROD'
+        table_pattern:
+            deny:
+            - '.*test.*'
+        aws_region: 'us-east-1'
+
+sink:
+    type: 'datahub-rest'
+    config:
+        server: 'http://localhost:8080'

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -533,6 +533,7 @@ entry_points = {
         "presto-on-hive = datahub.ingestion.source.sql.presto_on_hive:PrestoOnHiveSource",
         "pulsar = datahub.ingestion.source.pulsar:PulsarSource",
         "salesforce = datahub.ingestion.source.salesforce:SalesforceSource",
+        "dynamodb = datahub.ingestion.source.aws.dynamodb:DynamoDBSource",
         "affirm-artifact = datahub.ingestion.source.affirm.artifact:AffirmArtifactSource",
     ],
     "datahub.ingestion.sink.plugins": [

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/aws_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/aws_common.py
@@ -150,6 +150,12 @@ class AwsConnectionConfig(ConfigModel):
     def get_sagemaker_client(self) -> "SageMakerClient":
         return self.get_session().client("sagemaker")
 
+    def get_dynamodb_client(self) -> "DynamoDBClient":
+        return self.get_session().client("dynamodb")
+
+    def get_dynamodbstreams_client(self) -> "DynamoDBStreamsClient":
+        return self.get_session().client("dynamodbstreams")
+
 
 class AwsSourceConfig(EnvBasedSourceConfigBase, AwsConnectionConfig):
     """

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/dynamodb.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/dynamodb.py
@@ -1,0 +1,253 @@
+import logging
+from collections import OrderedDict
+from typing import Dict, Iterable, List
+from dataclasses import dataclass, field
+
+from datahub.configuration.source_common import PlatformSourceConfigBase
+from datahub.emitter.mce_builder import (
+    make_data_platform_urn,
+    make_dataset_urn,
+)
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.api.source import Source, SourceReport
+from datahub.ingestion.api.workunit import MetadataWorkUnit
+from datahub.ingestion.source.aws.aws_common import AwsSourceConfig
+from datahub.metadata.schema_classes import (
+    ChangeTypeClass,
+)
+from datahub.metadata.com.linkedin.pegasus2avro.schema import (
+    ArrayType,
+    BooleanType,
+    BytesType,
+    KeyValueSchema,
+    MapType,
+    NullType,
+    NumberType,
+    SchemaField,
+    SchemaFieldDataType,
+    SchemaMetadata,
+    StringType,
+)
+
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PLATFORM = "dynamodb"
+
+_attribute_type_mapping = {
+    "S": StringType,
+    "N": NumberType,
+    "B": BytesType,
+    "SS": ArrayType,
+    "NS": ArrayType,
+    "BS": ArrayType,
+    "M": MapType,
+    "L": ArrayType,
+    "BOOL": BooleanType,
+    "NULL": NullType,
+}
+
+
+class DynamoDBSourceConfig(AwsSourceConfig, PlatformSourceConfigBase):
+
+    ingest_tables: List[str] = None
+
+    @property
+    def dynamodb_client(self):
+        return self.get_dynamodb_client()
+
+    @property
+    def dynamodbstreams_client(self):
+        return self.get_dynamodbstreams_client()
+
+
+@dataclass
+class DynamoDBSourceReport(SourceReport):
+    filtered_tables: List[str] = field(default_factory=list)
+    streaming_disabled_tables: List[str] = field(default_factory=list)
+
+    def report_table_filtered(self, table: str) -> None:
+        self.filtered_tables.append(table)
+
+    def report_table_streaming_disabled(self, table: str) -> None:
+        self.streaming_disabled_tables.append(table)
+
+
+@dataclass
+class DynamoDBSource(Source):
+    config: DynamoDBSourceConfig
+    report: DynamoDBSourceReport()
+
+    def __init__(self, config: DynamoDBSourceConfig, ctx: PipelineContext):
+        super().__init__(ctx)
+        self.config = config
+        self.report = DynamoDBSourceReport()
+
+
+    @classmethod
+    def create(cls, source_config, context):
+        config = DynamoDBSourceConfig.parse_obj(source_config)
+        return cls(config, context)
+
+
+    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
+        if self.config.ingest_tables:
+            all_tables = self.config.ingest_tables
+        else:
+            all_tables = get_all_tables(self.config.dynamodb_client)
+        for table_name in all_tables:
+            logger.info(f"Processing table {table_name}")
+            if not self.config.table_pattern.allowed(table_name):
+                logger.info(f"Table {table_name} is not allowed by table_allow pattern")
+                self.report.report_table_filtered(table_name)
+                continue
+
+            wu = self.make_workunit(table_name)
+            if wu is None:
+                logger.info(f'Skip none work unit of table {table_name}')
+                continue
+            yield wu
+
+
+    def make_workunit(self, table_name: str):
+        table = describe_table(self.config.dynamodb_client, table_name)
+        dataset_urn = make_dataset_urn(DEFAULT_PLATFORM, table_name, self.config.env)
+        keys = [x["AttributeName"] for x in table.get("KeySchema", [])]
+
+        attribute_definitions = self.populate_attribute_definitions(table)
+        if attribute_definitions is None:
+            return None
+        schema_fields = self.get_schema_fields(attribute_definitions)
+        schema_metadata = SchemaMetadata(
+            schemaName=f"{table_name}",
+            platform=make_data_platform_urn(DEFAULT_PLATFORM),
+            version=0,
+            hash="",
+            platformSchema=KeyValueSchema(keySchema="", valueSchema=""),
+            fields=schema_fields,
+            primaryKeys=keys
+        )
+
+        mcp = MetadataChangeProposalWrapper(
+            entityType="dataset",
+            entityUrn=dataset_urn,
+            changeType=ChangeTypeClass.UPSERT,
+            aspectName="schemaMetadata",
+            aspect=schema_metadata
+        )
+        wu = MetadataWorkUnit(
+            id=dataset_urn,
+            mcp=mcp
+        )
+        return wu
+
+
+    def populate_attribute_definitions(self, table) -> Dict[str, str]:
+        raw_attribute_definitions = table["AttributeDefinitions"]
+        attribute_definitions = {
+            x["AttributeName"]: x["AttributeType"] for x in raw_attribute_definitions
+        }
+        if table.get("StreamSpecification", {}).get("StreamEnabled", False):
+            stream_arn = table["LatestStreamArn"]
+            attribute_definitions.update(
+                get_attribute_definitions(self.config.dynamodbstreams_client, stream_arn)
+            )
+        else:
+            table_name = table["TableName"]
+            logger.warn(f"Table {table_name} streaming is NOT enabled.")
+            self.report.report_table_streaming_disabled(table_name)
+            return None
+        return attribute_definitions
+
+
+    def get_schema_fields(self, attribute_definitions: Dict):
+        schema_fields = []
+        for (k, v) in attribute_definitions.items():
+            type_class = _attribute_type_mapping.get(v)
+            schemaField = SchemaField(
+                fieldPath=k,
+                type=SchemaFieldDataType(type=type_class()),
+                nativeDataType=v
+            )
+            schema_fields.append(schemaField)
+        return schema_fields
+
+
+    def get_report(self):
+        return self.report
+
+
+    def close(self):
+        pass
+
+
+def get_all_tables(dynamodb_client) -> List[str]:
+    tables = []
+    paginator = dynamodb_client.get_paginator("list_tables")
+    paginator_iterator = paginator.paginate()
+    for page in paginator_iterator:
+        tables += page["TableNames"]
+    return tables
+
+
+def describe_table(dynamodb_client, table_name: str) -> Dict:
+    response = dynamodb_client.describe_table(TableName=table_name)
+    table = response["Table"]
+    return table
+
+
+def get_attribute_definitions(dynamodbstreams_client, arn: str) -> Dict:
+    attribute_definitions = OrderedDict()
+    description_response = dynamodbstreams_client.describe_stream(StreamArn=arn)
+    description = description_response.get("StreamDescription", {})
+    shards = description.get("Shards", [])
+
+    for shard in shards:
+        latest_sequence_number = ''
+        completed = False
+        logger.info(f"Processing shard: {shard['ShardId']}, stream arn: {arn}")
+        while not completed:
+            if 'EndingSequenceNumber' not in shard['SequenceNumberRange']:
+                logger.info('The shard is still open, exiting')
+                break
+
+            call_kwargs = {
+                'StreamArn': arn,
+                'ShardId': shard["ShardId"],
+                'ShardIteratorType': 'TRIM_HORIZON'
+            }
+            if latest_sequence_number:
+                call_kwargs.update({
+                    'SequenceNumber': latest_sequence_number,
+                    'ShardIteratorType': 'AFTER_SEQUENCE_NUMBER'})
+
+            try:
+                shard_iterator_response = dynamodbstreams_client.get_shard_iterator(**call_kwargs)
+            except dynamodbstreams_client.exceptions.ResourceNotFoundException:
+                logger.warn(f'Shard is no longer available, id: {shard["ShardId"]}')
+                break
+
+            shard_iterator = shard_iterator_response["ShardIterator"]
+            while shard_iterator is not None:
+                try:
+                    records_response = dynamodbstreams_client.get_records(ShardIterator=shard_iterator)
+                except dynamodbstreams_client.exceptions.ExpiredIteratorException:
+                    logger.info('Shard Iterator expired, refreshing')
+                    break
+
+                records = records_response.get('Records', [])
+                if len(records) > 0:
+                    dynamodb_data = [x.get('dynamodb', {}) for x in records]
+                    latest_sequence_number = dynamodb_data[-1]['SequenceNumber']
+                    new_images = [x.get('NewImage', {}) for x in dynamodb_data]
+                    for new_image in new_images:
+                        for key in new_image.keys():
+                            if key not in attribute_definitions:
+                                type_value = new_image[key]
+                                t = list(type_value.keys())[0]
+                                attribute_definitions[key] = t
+                shard_iterator = records_response.get('NextShardIterator', None)
+                if shard_iterator is None:
+                    completed = True
+    return attribute_definitions


### PR DESCRIPTION
DynamoDB ingestion is through
1. Load the `attributes` from aws dynamodb `describe table`
2. Load table recent streams to fetch item images, and derive the schema from the item images

We also support filter tables by `AllowDenyPattern` and report any table that didn't enable streaming.


> Steps to run the ingestion job
1. aws login
2. populate `dynamodb_to_datahub.yml` recipe with configs (copy from `~/.aws/credentails`)
2.1 `aws_region`
2.2 `aws_access_key_id`
2.3 `aws_secret_key_id`
2.4 `aws_session_token`
2. start k8s port forward for datahub gms pod
3. run command `datahub ingest -c examples/recipes/dynamodb_to_datahub.yml `
