### PR TITLE
Add token auth for report generator

### DIFF
--- a/metadata-ingestion/src/datahub/cli/generate_report/config.py
+++ b/metadata-ingestion/src/datahub/cli/generate_report/config.py
@@ -30,6 +30,7 @@ class Output(ConfigModel):
 
 class GenerateReportConfig(ConfigModel):
     datahub_base_url: str
+    datahub_token: str
     # Search query strings for https://datahubproject.io/docs/graphql/queries#search
     search_queries: List[str]
     # Page size to use for the graphql query when fetching search results

--- a/metadata-ingestion/tests/unit/report_generator/test_report_generator.py
+++ b/metadata-ingestion/tests/unit/report_generator/test_report_generator.py
@@ -73,10 +73,11 @@ class TestReportGenerator(TestCase):
         rg.generate()
 
         mock_privacy_term_extractor_class.assert_called_once_with(
-            self.config["datahub_base_url"], self.config["datahub_token"]
+            self.config["datahub_base_url"],
+            self.config["datahub_token"],
         )
         mock_extractor.yield_search_results_assert_called_once_with(
-            self.config["search_queries"]
+            self.config["search_queries"],
         )
 
         with open(os.path.join(FIXTURES_PATH, "expected_basic.csv"), "rb") as f:
@@ -258,7 +259,7 @@ class TestPrivacyTermExtractor(TestCase):
                 call(
                     "http://localhost:1234/api/graphql",
                     headers={
-                        "Authorization": "Bearer TOKEN"
+                        "Authorization": "Bearer TOKEN",
                     },
                     json={
                         "query": extractor.GRAPHQL_QUERY,
@@ -272,7 +273,7 @@ class TestPrivacyTermExtractor(TestCase):
                 call(
                     "http://localhost:1234/api/graphql",
                     headers={
-                        "Authorization": "Bearer TOKEN"
+                        "Authorization": "Bearer TOKEN",
                     },
                     json={
                         "query": extractor.GRAPHQL_QUERY,

--- a/metadata-ingestion/tests/unit/report_generator/test_report_generator.py
+++ b/metadata-ingestion/tests/unit/report_generator/test_report_generator.py
@@ -19,6 +19,7 @@ class TestReportGenerator(TestCase):
         self.tmp_output_file = tempfile.NamedTemporaryFile()
         self.config = {
             "datahub_base_url": "http://localhost:1234",
+            "datahub_token": "TOKEN",
             "search_queries": ["*"],
             "output": {
                 "format": "csv",
@@ -72,7 +73,7 @@ class TestReportGenerator(TestCase):
         rg.generate()
 
         mock_privacy_term_extractor_class.assert_called_once_with(
-            self.config["datahub_base_url"]
+            self.config["datahub_base_url"], self.config["datahub_token"]
         )
         mock_extractor.yield_search_results_assert_called_once_with(
             self.config["search_queries"]
@@ -203,7 +204,7 @@ class TestPrivacyTermExtractor(TestCase):
                 "privacy_law": [],
             },
         ]
-        extractor = PrivacyTermExtractor("http://localhost:1234")
+        extractor = PrivacyTermExtractor("http://localhost:1234", "TOKEN")
 
         actual = list(extractor.yield_search_results(["snowflake"]))
         mock_post.assert_called_once()
@@ -249,13 +250,16 @@ class TestPrivacyTermExtractor(TestCase):
         mock_post.side_effect = [response1, response2]
 
         extractor = PrivacyTermExtractor(
-            "http://localhost:1234", search_query_page_size=10
+            "http://localhost:1234", "TOKEN", search_query_page_size=10
         )
         actual = list(extractor.yield_search_results(["snowflake"]))
         mock_post.assert_has_calls(
             [
                 call(
                     "http://localhost:1234/api/graphql",
+                    headers={
+                        "Authorization": "Bearer TOKEN"
+                    },
                     json={
                         "query": extractor.GRAPHQL_QUERY,
                         "variables": {
@@ -267,6 +271,9 @@ class TestPrivacyTermExtractor(TestCase):
                 ),
                 call(
                     "http://localhost:1234/api/graphql",
+                    headers={
+                        "Authorization": "Bearer TOKEN"
+                    },
                     json={
                         "query": extractor.GRAPHQL_QUERY,
                         "variables": {
@@ -303,7 +310,7 @@ class TestPrivacyTermExtractor(TestCase):
         mock_post.side_effect = [response1]
 
         expected = []
-        extractor = PrivacyTermExtractor("http://localhost:1234")
+        extractor = PrivacyTermExtractor("http://localhost:1234", "TOKEN")
 
         actual = list(extractor.yield_search_results(["snowflake"]))
         mock_post.assert_called_once()


### PR DESCRIPTION
We need token auth for report generation when DataHub GMS auth is turned on.