### PR TITLE
fix(cli) make generate-report to flush on write

### DIFF
--- a/metadata-ingestion/src/datahub/cli/generate_report/report_generator.py
+++ b/metadata-ingestion/src/datahub/cli/generate_report/report_generator.py
@@ -203,6 +203,7 @@ class OutputWriter:
             self._write_csv(rows)
         else:
             raise ValueError(f"unhandled output format: {self.output_format}")
+        self.fileobj.flush()
 
     def _write_csv(self, rows: Iterable[Dict]) -> None:
         fieldnames = ["dataset", "field", "type", "privacy_law"]


### PR DESCRIPTION
Rows were not getting written to the file so we were missing a few lines in our reports generated.

https://github.com/Affirm/datahub/blob/573ce9599a9778b33bf0da620ede088ddba43fff/metadata-ingestion/src/datahub/cli/generate_report/report_generator.py#L32-L34

**Testing**
Ran locally w/ dynamodb report and ensured we're getting all the rows that we expected.