### PR TITLE
feat(ingest): fix dynamodb unpack value error cus missing .items()

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/aws/dynamodb.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/dynamodb.py
@@ -167,7 +167,7 @@ class DynamoDBSource(Source):
 
         if table.get("StreamSpecification", {}).get("StreamEnabled", False):
             stream_arn = table["LatestStreamArn"]
-            for attr, new_value in get_attribute_definitions(self.config.dynamodbstreams_client, stream_arn):
+            for attr, new_value in get_attribute_definitions(self.config.dynamodbstreams_client, stream_arn).items():
                 existing_value = attribute_definitions.get(attr)
                 if existing_value is not None and existing_value != new_value:
                     logger.warn(f'Overwriting {attr} type: was {existing_value} but now is {new_value}')


### PR DESCRIPTION
```
 Traceback (most recent call last):                                                                                                                                                                                 │
│   File "/usr/local/lib/python3.10/site-packages/datahub/entrypoints.py", line 151, in main                                                                                                                         │
│     sys.exit(datahub(standalone_mode=False, **kwargs))                                                                                                                                                             │
│   File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1130, in __call__                                                                                                                             │
│     return self.main(*args, **kwargs)                                                                                                                                                                              │
│   File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1055, in main                                                                                                                                 │
│     rv = self.invoke(ctx)                                                                                                                                                                                          │
│   File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1657, in invoke                                                                                                                               │
│     return _process_result(sub_ctx.command.invoke(sub_ctx))                                                                                                                                                        │
│   File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1657, in invoke                                                                                                                               │
│     return _process_result(sub_ctx.command.invoke(sub_ctx))                                                                                                                                                        │
│   File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1404, in invoke                                                                                                                               │
│     return ctx.invoke(self.callback, **ctx.params)                                                                                                                                                                 │
│   File "/usr/local/lib/python3.10/site-packages/click/core.py", line 760, in invoke                                                                                                                                │
│     return __callback(*args, **kwargs)                                                                                                                                                                             │
│   File "/usr/local/lib/python3.10/site-packages/click/decorators.py", line 26, in new_func                                                                                                                         │
│     return f(get_current_context(), *args, **kwargs)                                                                                                                                                               │
│   File "/usr/local/lib/python3.10/site-packages/datahub/telemetry/telemetry.py", line 347, in wrapper                                                                                                              │
│     raise e                                                                                                                                                                                                        │
│   File "/usr/local/lib/python3.10/site-packages/datahub/telemetry/telemetry.py", line 299, in wrapper                                                                                                              │
│     res = func(*args, **kwargs)                                                                                                                                                                                    │
│   File "/usr/local/lib/python3.10/site-packages/datahub/utilities/memory_leak_detector.py", line 102, in wrapper                                                                                                   │
│     return func(*args, **kwargs)                                                                                                                                                                                   │
│   File "/usr/local/lib/python3.10/site-packages/datahub/cli/ingest_cli.py", line 207, in run                                                                                                                       │
│     loop.run_until_complete(run_func_check_upgrade(pipeline))                                                                                                                                                      │
│   File "/usr/local/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete                                                                                                                         │
│     return future.result()                                                                                                                                                                                         │
│   File "/usr/local/lib/python3.10/site-packages/datahub/cli/ingest_cli.py", line 163, in run_func_check_upgrade                                                                                                    │
│     ret = await the_one_future                                                                                                                                                                                     │
│   File "/usr/local/lib/python3.10/site-packages/datahub/cli/ingest_cli.py", line 154, in run_pipeline_async                                                                                                        │
│     return await loop.run_in_executor(                                                                                                                                                                             │
│   File "/usr/local/lib/python3.10/concurrent/futures/thread.py", line 58, in run                                                                                                                                   │
│     result = self.fn(*self.args, **self.kwargs)                                                                                                                                                                    │
│   File "/usr/local/lib/python3.10/site-packages/datahub/cli/ingest_cli.py", line 145, in run_pipeline_to_completion                                                                                                │
│     raise e                                                                                                                                                                                                        │
│   File "/usr/local/lib/python3.10/site-packages/datahub/cli/ingest_cli.py", line 131, in run_pipeline_to_completion                                                                                                │
│     pipeline.run()                                                                                                                                                                                                 │
│   File "/usr/local/lib/python3.10/site-packages/datahub/ingestion/run/pipeline.py", line 338, in run                                                                                                               │
│     for wu in itertools.islice(                                                                                                                                                                                    │
│   File "/usr/local/lib/python3.10/site-packages/datahub/ingestion/source/aws/dynamodb.py", line 113, in get_workunits                                                                                              │
│     wu = self.make_workunit(table_name)                                                                                                                                                                            │
│   File "/usr/local/lib/python3.10/site-packages/datahub/ingestion/source/aws/dynamodb.py", line 129, in make_workunit                                                                                              │
│     attribute_definitions = self.populate_attribute_definitions(table)                                                                                                                                             │
│   File "/usr/local/lib/python3.10/site-packages/datahub/ingestion/source/aws/dynamodb.py", line 170, in populate_attribute_definitions                                                                             │
│     for attr, new_value in get_attribute_definitions(self.config.dynamodbstreams_client, stream_arn):                                                                                                              │
│ ValueError: too many values to unpack (expected 2)
```