### PR TITLE
set package version

### DIFF
--- a/metadata-ingestion-modules/airflow-plugin/src/datahub_airflow_plugin/__init__.py
+++ b/metadata-ingestion-modules/airflow-plugin/src/datahub_airflow_plugin/__init__.py
@@ -1,6 +1,6 @@
 # Published at https://pypi.org/project/acryl-datahub/.
 __package_name__ = "acryl-datahub-airflow-plugin"
-__version__ = "0.0.0.dev0"
+__version__ = "0.10.1+affirm4"
 
 
 def is_dev_mode() -> bool:

--- a/metadata-ingestion/src/datahub/__init__.py
+++ b/metadata-ingestion/src/datahub/__init__.py
@@ -3,7 +3,7 @@ import warnings
 
 # Published at https://pypi.org/project/acryl-datahub/.
 __package_name__ = "acryl-datahub"
-__version__ = "0.0.0.dev0"
+__version__ = "0.10.1+affirm4"
 
 
 def is_dev_mode() -> bool:


### PR DESCRIPTION
Set package versions for pushing packages from affirm's fork of datahub.

With this change we are publishing 2 packages:

1) acryl_datahub-0.10.1+affirm4
    - This will also contain plugin packages like acryl_datahub[airflow], acryl_datahub[datahub-kafka]
2) acryl-datahub-airflow-plugin-0.10.1+affirm4

For future reference: 
- To push new packages in affirm folllow this [wiki](https://confluence.team.affirm.com/display/EN/Artifactory+User+Guide)
- Direcories where setup.py exist
    - datahub/metadata-ingestion/
    - datahub/metadata-ingestion-modules/airflow-plugin
 