### PR TITLE
yield workunit with status

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/aws/dynamodb.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/dynamodb.py
@@ -17,6 +17,7 @@ from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.aws.aws_common import AwsSourceConfig
 from datahub.metadata.schema_classes import (
     ChangeTypeClass,
+    StatusClass
 )
 from datahub.metadata.com.linkedin.pegasus2avro.schema import (
     ArrayType,
@@ -112,6 +113,12 @@ class DynamoDBSource(Source):
                 continue
             yield wu
 
+            # add status
+            dataset_urn = make_dataset_urn(DEFAULT_PLATFORM, table_name, self.config.env)
+            yield MetadataChangeProposalWrapper(
+                entityUrn=f"{dataset_urn}",
+                aspect=StatusClass(removed=False),
+            ).as_workunit()
 
     def make_workunit(self, table_name: str):
         table = describe_table(self.config.dynamodb_client, table_name)


### PR DESCRIPTION
## Checklist

Annotations are missing for DynamoDB tables on DataHub. For example, the chargedetails table has a [ton of field-level annotations in the repo](https://github.com/Affirm/datahub-metadata/blob/main/datasets/dynamodb/prod-live/global.affirm.chargedetails.yaml), but [none of them are on DataHub](https://datahub.prod-analytics-main.affirm-keyhole.com/dataset/urn:li:dataset:(urn:li:dataPlatform:dynamodb,prod-live.global.affirm.chargedetails,PROD)/Schema?is_lineage_mode=false&schemaFilter=).
The reason for this is that ‘status’ is None for these datasets, and [this logic](https://github.com/Affirm/datahub-metadata/blob/7b2d4ce5e9cfd80d971816cb3a9c4e8e13b07435/internal/code/datahub_metadata/exports/export_annotations_to_datahub.py#L310) in the export script is skipping because of that. Looks like we are not publishing [status](https://datahubproject.io/docs/graphql/objects#status) for DynamoDB tables in our [ingestion logic](https://github.com/Affirm/datahub/blob/v0.10.1.affirm/metadata-ingestion/src/datahub/ingestion/source/aws/dynamodb.py), and we should be doing that.

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
